### PR TITLE
use new network machine format

### DIFF
--- a/create-cluster/hub/aws/install_config.yaml
+++ b/create-cluster/hub/aws/install_config.yaml
@@ -30,7 +30,8 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - cidr: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16

--- a/create-cluster/hub/azure/install_config.yaml
+++ b/create-cluster/hub/azure/install_config.yaml
@@ -30,7 +30,8 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - cidr: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16
@@ -41,4 +42,3 @@ platform:
 pullSecret: "" # skip, hive will inject based on it's secrets
 sshKey: |-
 {{ .managedCluster.sshPublicKey | indent 4 }}
-    

--- a/create-cluster/hub/gcp/install_config.yaml
+++ b/create-cluster/hub/gcp/install_config.yaml
@@ -22,7 +22,8 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - cidr: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16
@@ -33,4 +34,3 @@ platform:
 pullSecret: "" # skip, hive will inject based on it's secrets
 sshKey: |-
   {{ .managedCluster.sshPublicKey | indent 4 }}
-    

--- a/create-cluster/hub/vsphere/install_config.yaml
+++ b/create-cluster/hub/vsphere/install_config.yaml
@@ -26,14 +26,6 @@ compute:
       memoryMB:  16384
       osDisk:
         diskSizeGB: 120
-networking:
-  clusterNetwork:
-  - cidr: 10.128.0.0/14
-    hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
-  networkType: OpenShiftSDN
-  serviceNetwork:
-  - 172.30.0.0/16
 platform:
   vsphere:
     vCenter: {{ .managedCluster.vsphere.vcenter }}


### PR DESCRIPTION
Since Openshift 4.4, the install-config supports a new network machine format.  The old one will be deprecated at some point so we need to switch to the new way.